### PR TITLE
Only mods needed for operation on Terry's dev system.

### DIFF
--- a/CwHelperC/src/com/cwepg/build/BuildExeFromClassFiles.java
+++ b/CwHelperC/src/com/cwepg/build/BuildExeFromClassFiles.java
@@ -35,15 +35,15 @@ public class BuildExeFromClassFiles {
      * Changes made here now must be copied to the alternative source control project (use WinMerge on c:\my\dev\eclipsewrk\CwHelper and C:\my\dev\gitrepo\CwHelperC).         
      * 
      */
-    public static final String USER = "C:\\Users\\Owner\\";
-    public static final String PROJECT_DIRECTORY = USER + "github\\cwhelper\\CwHelperC\\";
+    public static final String USER = "C:\\Users\\tmpet\\";
+    public static final String PROJECT_DIRECTORY = USER + "git\\cwhelper\\CwHelperC\\";
     public static final String J2E_WIZ = "C:\\Program Files (x86)\\Jar2Exe Wizard\\j2ewiz.exe";
     public static final String KEYSTORE = "C:\\Users\\Owner\\AndroidStudioProjects\\KnurderKeyStore.jks";
     public static final String LIBRARY_DIRECTORY = PROJECT_DIRECTORY + "CwHelper_lib\\";
     public static final String VERSION_FILE_NAME = "version.txt";
     public static final String STOREPASS = "Hnds#1111";
     public static final String KEYPASS = "Hnds#1111";
-    public static final String JRE_PATH = "C:\\Program Files\\Java\\jdk-18.0.2.1\\";
+    public static final String JRE_PATH = "C:\\Program Files\\Eclipse Adoptium\\jdk-11.0.15.10-hotspot\\";
     public static final String BASE_VERSION = "5-4-0-";
     public static final String COMMA_VERSION = "5,4,0,";
     public static final String DOT_VERSION = "5.4.0.";
@@ -52,7 +52,7 @@ public class BuildExeFromClassFiles {
     	
         boolean doJarSigning = false; // DRS 20230513 - Signing prevents Terry from iterating on his own.
         
-        boolean forceRevisionNumber = true; //>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+        boolean forceRevisionNumber = false; //>>>>>>>>>>>>>>>>>>>>>>>>>>>>
         String revision = "999";
         if (forceRevisionNumber) {
             revision = "1025";


### PR DESCRIPTION
When I started over by cloning sengsational's repository today I found that I had to change a few lines in BuildExeFromClassFiles.java.  The clearly necessary change was to the USER definition, which I remember adding last year.  But I also had to modify the JRE_PATH and set forceRevisionNumber to false. It's been over a year since I set this up previously, but I don't remember needing to change the JRE_PATH last time.  Did you change it from the path installed (I think) by Eclipse?

With this PR, I think we'll have a version of BuildExeFromClassFiles.java that works for us both with only a change in USER.