### PR TITLE
Rework startup paths for Win 11 work around

### DIFF
--- a/CwHelperC/src/com/cwepg/build/BuildExeFromClassFiles.java
+++ b/CwHelperC/src/com/cwepg/build/BuildExeFromClassFiles.java
@@ -35,15 +35,15 @@ public class BuildExeFromClassFiles {
      * Changes made here now must be copied to the alternative source control project (use WinMerge on c:\my\dev\eclipsewrk\CwHelper and C:\my\dev\gitrepo\CwHelperC).         
      * 
      */
-    public static final String USER = "C:\\Users\\Owner\\";
-    public static final String PROJECT_DIRECTORY = USER + "github\\cwhelper\\CwHelperC\\";
+    public static final String USER = "C:\\Users\\tmpet\\";
+    public static final String PROJECT_DIRECTORY = USER + "git\\cwhelper\\CwHelperC\\";
     public static final String J2E_WIZ = "C:\\Program Files (x86)\\Jar2Exe Wizard\\j2ewiz.exe";
     public static final String KEYSTORE = "C:\\Users\\Owner\\AndroidStudioProjects\\KnurderKeyStore.jks";
     public static final String LIBRARY_DIRECTORY = PROJECT_DIRECTORY + "CwHelper_lib\\";
     public static final String VERSION_FILE_NAME = "version.txt";
     public static final String STOREPASS = "Hnds#1111";
     public static final String KEYPASS = "Hnds#1111";
-    public static final String JRE_PATH = "C:\\Program Files\\Java\\jdk-18.0.2.1\\";
+    public static final String JRE_PATH = "C:\\Program Files\\Eclipse Adoptium\\jdk-11.0.15.10-hotspot\\";
     public static final String BASE_VERSION = "5-4-0-";
     public static final String COMMA_VERSION = "5,4,0,";
     public static final String DOT_VERSION = "5.4.0.";
@@ -52,7 +52,7 @@ public class BuildExeFromClassFiles {
     	
         boolean doJarSigning = false; // DRS 20230513 - Signing prevents Terry from iterating on his own.
         
-        boolean forceRevisionNumber = true; //>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+        boolean forceRevisionNumber = false; //>>>>>>>>>>>>>>>>>>>>>>>>>>>>
         String revision = "999";
         if (forceRevisionNumber) {
             revision = "1025";

--- a/CwHelperC/src/org/cwepg/hr/ServiceLauncher.java
+++ b/CwHelperC/src/org/cwepg/hr/ServiceLauncher.java
@@ -68,11 +68,7 @@ public class ServiceLauncher {
             String pathFromFile = in.readLine();
             
             cwepgExecutablePath         = pathFromFile;
-            hdhrPath                    = pathFromFile;
-            dataPath                    = pathFromFile;
             cwepgExecutablePathSource   = "the path found in file: " + new File("CwHdHrDir.txt").getPath();
-            hdhrPathSource              = cwepgExecutablePathSource;
-            dataPathSource              = cwepgExecutablePathSource;
             in.close();
         } catch (Throwable e) {
             // stays empty if the file is not found

--- a/CwHelperC/src/org/cwepg/hr/ServiceLauncher.java
+++ b/CwHelperC/src/org/cwepg/hr/ServiceLauncher.java
@@ -45,12 +45,9 @@ public class ServiceLauncher {
                 cwepgExecutablePathSource   = "the path found in registry HKEY_LOCAL_MACHINE\\SOFTWARE\\CW_EPG\\cwepgfolder";
                 hdhrPathSource              = cwepgExecutablePathSource;
                 dataPathSource              = cwepgExecutablePathSource;
-            } else {
-                throw new Exception(" HKEY_LOCAL_MACHINE\\SOFTWARE\\CW_EPG\\cwepgfolder not found.");
             }
         } catch (Throwable e1) {
-            // DRS 20231018 - throw exception if there is an error accessing the registry
-            throw(e1);
+            // stays empty if there is an error accessing the registry (reverse a86a97b)
         }
         
         try {
@@ -59,12 +56,9 @@ public class ServiceLauncher {
             if (cwepgdatafolder != null){
                 dataPath                    = cwepgdatafolder;
                 dataPathSource              = "the path found in registry HKEY_LOCAL_MACHINE\\SOFTWARE\\CW_EPG\\cwepgdatafolder";
-            } else {
-                throw new Exception(" HKEY_LOCAL_MACHINE\\SOFTWARE\\CW_EPG\\cwepgdatafolder not found.");
             }
         } catch (Throwable e1) {
-            // DRS 20231018 - throw exception if there is an error accessing the registry
-            throw(e1);
+            // stays empty if there is an error accessing the registry (reverse a86a97b)
         }
         
 
@@ -93,6 +87,18 @@ public class ServiceLauncher {
             }
         } catch (Throwable e1) {
             // stays empty if there is an error accessing the registry
+        }
+
+        //DRS 20241108 - Added try/catch - overwrite the data path if "ProgramData" is populated in the Windows environment
+        try {
+            // overwrite previous data path if "ProgramData" is populated
+            String programDataFolderFromWindows = System.getenv("ProgramData");
+            if (programDataFolderFromWindows != null){
+                dataPath = programDataFolderFromWindows + "\\CW_EPG";
+                dataPathSource = "the path found by System.getenv(\"ProgramData\") method";
+            }
+        } catch (Throwable e1) {
+            // stays empty if there is an error accessing the environment variable
         }
         
         // DRS20210306 - Added boolean and try/catch


### PR DESCRIPTION
The goal here was to change the way the three paths (cwepg executable path, hdhr executable path, and application data path) are assigned when CwHelper starts.  It's complicated by the fact that we're trying to run on XP through Windows 11.  Security measures, presumably, prevent Windows 11 from using the earlier technique of Windows registry access.  So a text file that was originally created to enable testing on non-production systems has been leveraged to work around the Windows registry issue.

See emails from 11/8/2024 +/-:

> Here’s my rationale on the text file.  First, it isn’t used/needed in non-Store installations, because the Registry values that CW_EPG always provides will be available to all apps.  Second, it is created by the Store version of CW_EPG IFF running on Win11 post-21H2 when the workaround is triggered.  But then it isn’t really required unless someone manually launches CWHelper.exe in the data folder because in that circumstance CWHelper won’t have any (easy) way of finding CW_EPG’s actual folder path, unlike when it’s launched by CW_EPG or the Store package’s CWHelper launcher with that path as the “start in” folder.  IOW it’s a failsafe for manual user intervention of the workaround configuration only.